### PR TITLE
call `setState` before `return` in useEmoji handler command

### DIFF
--- a/packages/@remirror/react-hooks/src/use-emoji.ts
+++ b/packages/@remirror/react-hooks/src/use-emoji.ts
@@ -49,8 +49,8 @@ function useEmojiChangeHandler(setState: SetEmojiState) {
           list: emojiMatches,
           index: 0,
           command: (emoji, skinVariation) => {
-            return command(emoji, skinVariation);
             setState(null);
+            return command(emoji, skinVariation);
           },
           range,
         });


### PR DESCRIPTION
in the source code, `setState` was being called after `return` in the `useEmojiChangeHandler` `command` handler. 

That meant `setState` was unreachable and was stripped in the distributed files.

Not calling `setState` led to a situation where using the `SocialEmojiComponent` would remain open even after selecting an emoji.

This PR rearranges the `return` and call to `setState` so that the `state` is set to `null`.

From `use-emoji/dist/react-hooks.esm.js`:

```
  if (changeReason) {
      setState({
        list: emojiMatches,
        index: 0,
        command: (emoji, skinVariation) => {
          return _command(emoji, skinVariation); // no call to `setState`
        },
        range
      });
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.


